### PR TITLE
Fixed DEV-21683 : Wound imaging crashed when zoom camera was also on

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -23,6 +23,10 @@
     <source-file src="src/android/camera_theme.xml" target-dir="res/values" />
     <source-file src="src/android/camera_ids.xml" target-dir="res/values" />
 
+    <config-file target="res/values/strings.xml" parent="/*">
+      <string name="camera_preview_error">Unable to load camera, please try turning off camera used by any other functionality and try again</string>
+    </config-file> 
+
     <framework src="androidx.exifinterface:exifinterface:1.2.0" />
 
     <config-file target="res/xml/config.xml" parent="/*">

--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -37,6 +37,8 @@ import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
+import android.widget.Toast;
+
 import androidx.exifinterface.media.ExifInterface;
 
 import org.apache.cordova.LOG;
@@ -283,8 +285,13 @@ public class CameraActivity extends Fragment {
   @Override
   public void onResume() {
     super.onResume();
-
-    mCamera = Camera.open(defaultCameraId);
+    try {
+        mCamera = Camera.open(defaultCameraId);  // open camera
+    } catch (RuntimeException e) {
+        Log.e(TAG, "Failed to open camera: " + e.getMessage());
+        // may be as one of the default camera stream is already running thus it has failed to open camera
+        Toast.makeText(getContext(), "Unable to load camera, please try turning off camera used by any other functionality and try again", Toast.LENGTH_LONG).show();
+    }
 
     if (cameraParameters != null) {
       mCamera.setParameters(cameraParameters);

--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -289,8 +289,9 @@ public class CameraActivity extends Fragment {
         mCamera = Camera.open(defaultCameraId);  // open camera
     } catch (RuntimeException e) {
         Log.e(TAG, "Failed to open camera: " + e.getMessage());
+        int resId = getActivity().getResources().getIdentifier("camera_preview_error", "string", getActivity().getPackageName());
         // may be as one of the default camera stream is already running thus it has failed to open camera
-        Toast.makeText(getContext(), "Unable to load camera, please try turning off camera used by any other functionality and try again", Toast.LENGTH_LONG).show();
+        Toast.makeText(getContext(), getActivity().getResources().getString(resId), Toast.LENGTH_LONG).show();
     }
 
     if (cameraParameters != null) {


### PR DESCRIPTION
This MR addresses the issue where we are getting exception when there is an ongoing zoom call and we open the wound imaging module (which turns on the camera preview).
To provide a graceful handling, we are catching the exception and logging it. Though in our app we have handled it by temporarily turning off zoom camera but still in this plugin as a safe check we are applying this logic. 